### PR TITLE
Replace cargo-xbuild with build-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,3 @@ crate-type = ["staticlib"]
 [dependencies]
 redox_uefi = "0.1.0"
 redox_uefi_std = "0.1.0"
-
-[package.metadata.cargo-xbuild]
-memcpy = true
-sysroot_path = "build/xbuild"

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,8 @@ $(BUILD)/boot.o: $(BUILD)/boot.a
 
 $(BUILD)/boot.a: Cargo.lock Cargo.toml src/*
 	mkdir -p $(BUILD)
-	cargo xrustc \
+	cargo rustc \
+		-Z build-std=core,alloc \
 		--lib \
 		--target $(TARGET) \
 		--release \


### PR DESCRIPTION
Use [build-std](https://doc.rust-lang.org/cargo/reference/unstable.html#build-std) instead of cargo-xbuild.