### PR TITLE
Remove use of prelude_import

### DIFF
--- a/src/gop_policy.rs
+++ b/src/gop_policy.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use core::ops::FromResidual;
+use std::prelude::*;
 use std::uefi::Handle;
 use std::uefi::boot::InterfaceType;
 use std::uefi::guid::{Guid, NULL_GUID};

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,15 +2,12 @@
 
 #![no_std]
 #![no_main]
-#![feature(prelude_import)]
 #![feature(try_trait_v2)]
 #![allow(non_snake_case)]
 
 #[macro_use]
 extern crate uefi_std as std;
 
-#[allow(unused_imports)]
-#[prelude_import]
 use std::prelude::*;
 
 use core::ops::FromResidual;


### PR DESCRIPTION
Fixes the following warning:

    warning: the feature `prelude_import` is internal to the compiler or standard library
     --> src/main.rs:5:12
      |
    5 | #![feature(prelude_import)]
      |            ^^^^^^^^^^^^^^
      |
      = note: using it is strongly discouraged
      = note: `#[warn(internal_features)]` on by default