### PR TITLE
Update Rust toolchain to nightly-2024-05-11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,24 +4,24 @@ version = 3
 
 [[package]]
 name = "redox_uefi"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4143e69d22c9f79fd22cb37859a06af4936741c8ef70b5d6338953717feb68a5"
+checksum = "ad1ef8d2afbe5adfc257e0847f360d0f175e7012c4fa984a284966b54ad5834d"
 
 [[package]]
 name = "redox_uefi_alloc"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d12654bc506da36550bbd8e77438be985b839afdc98c0956fc7fd10fa9b45022"
+checksum = "12fe0357fd0ecc7c7de510c9add51a52a9268c3fa5890f9c8dbef890e4b2d1f6"
 dependencies = [
  "redox_uefi",
 ]
 
 [[package]]
 name = "redox_uefi_std"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9dea5dc3b2366e4611520a4983b27aa11f373c86f774eff1fd3f93d040c0ebd"
+checksum = "2a19dfc2a64c4a152fff1819c6ce74460c322a46da9c812ffaa1282260c19ec2"
 dependencies = [
  "redox_uefi",
  "redox_uefi_alloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ license = "GPL-3.0-only"
 lto = true
 
 [dependencies]
-redox_uefi_std = "0.1.9"
+redox_uefi_std = "0.1.12"

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ $(BUILD)/boot.efi: Cargo.lock Cargo.toml src/*
 	mkdir -p $(BUILD)
 	cargo rustc \
 		-Z build-std=core,alloc \
-		--target $(TARGET) \
+		--target=$(TARGET) \
 		--release \
 		-- \
 		-C soft-float \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-09-07"
+channel = "nightly-2024-05-11"
 components = ["rust-src"]

--- a/targets/x86_64-unknown-uefi-drv.json
+++ b/targets/x86_64-unknown-uefi-drv.json
@@ -4,7 +4,7 @@
   "arch": "x86_64",
   "code-model": "large",
   "cpu": "x86-64",
-  "data-layout": "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  "data-layout": "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
   "disable-redzone": true,
   "emit-debug-gdb-scripts": false,
   "env": "",


### PR DESCRIPTION
Update toolchain to match the version used in Redox.