### PR TITLE
Remove use of build-std

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,6 @@ $(BUILD)/efi.img: $(BUILD)/boot.efi
 $(BUILD)/boot.efi: Cargo.lock Cargo.toml src/*
 	mkdir -p $(BUILD)
 	cargo rustc \
-		-Z build-std=core,alloc \
 		--target $(TARGET) \
 		--release \
 		-- \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "nightly-2024-05-11"
-components = ["rust-src"]
+targets = ["x86_64-unknown-uefi"]
+profile = "minimal"


### PR DESCRIPTION
x86_64-unknown-uefi is a tier 2 supported target [1] that provides core and alloc (with redox_uefi providing the allocator). Nightly compiler options for building them are not needed.

[1]: https://doc.rust-lang.org/1.78.0/rustc/platform-support/unknown-uefi.html