### PR TITLE
Update redox_uefi_std to 0.1.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,24 +4,24 @@ version = 3
 
 [[package]]
 name = "redox_uefi"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1ef8d2afbe5adfc257e0847f360d0f175e7012c4fa984a284966b54ad5834d"
+checksum = "c5d69301333534a04b380995f5d9e604f46a7cbd8d8c62c996ee27447efdeba4"
 
 [[package]]
 name = "redox_uefi_alloc"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12fe0357fd0ecc7c7de510c9add51a52a9268c3fa5890f9c8dbef890e4b2d1f6"
+checksum = "1df364cdf289d9df9201f147aeeb5e7387f29f0824bee2e41e960eb98eaf03f1"
 dependencies = [
  "redox_uefi",
 ]
 
 [[package]]
 name = "redox_uefi_std"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a19dfc2a64c4a152fff1819c6ce74460c322a46da9c812ffaa1282260c19ec2"
+checksum = "b81203f45b2e08804d80274a2951f1615828d9aa5629d3a5d267878c70feb96d"
 dependencies = [
  "redox_uefi",
  "redox_uefi_alloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ license = "GPL-3.0-only"
 lto = true
 
 [dependencies]
-redox_uefi_std = "0.1.12"
+redox_uefi_std = "0.1.13"

--- a/src/gop_policy.rs
+++ b/src/gop_policy.rs
@@ -1,16 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use core::ops::FromResidual;
 use std::prelude::*;
-use std::uefi::Handle;
 use std::uefi::boot::InterfaceType;
-use std::uefi::guid::{Guid, NULL_GUID};
 use std::uefi::memory::PhysicalAddress;
-use std::uefi::status::{Error, Result, Status};
 
 static VBT: &[u8] = include_bytes!(env!("FIRMWARE_OPEN_VBT"));
 
-pub static GOP_POLICY_GUID: Guid = Guid(0xec2e931b,0x3281,0x48a5,[0x81,0x7,0xdf,0x8a,0x8b,0xed,0x3c,0x5d]);
+pub static GOP_POLICY_GUID: Guid = guid!("ec2e931b-3281-48a5-8107-df8a8bed3c5d");
 pub const GOP_POLICY_REVISION: u32 = 0x03;
 
 #[allow(unused)]
@@ -31,18 +27,18 @@ pub enum DockStatus {
 
 extern "win64" fn GetPlatformLidStatus(CurrentLidStatus: *mut LidStatus) -> Status {
     if CurrentLidStatus.is_null() {
-        return Status::from_residual(Error::InvalidParameter);
+        return Status::INVALID_PARAMETER;
     }
 
     // TODO: Get real lid status
     unsafe { *CurrentLidStatus = LidStatus::LidOpen };
 
-    Status(0)
+    Status::SUCCESS
 }
 
 extern "win64" fn GetVbtData(VbtAddress: *mut PhysicalAddress, VbtSize: *mut u32) -> Status {
     if VbtAddress.is_null() || VbtSize.is_null() {
-        return Status::from_residual(Error::InvalidParameter);
+        return Status::INVALID_PARAMETER;
     }
 
     unsafe { *VbtAddress = PhysicalAddress(VBT.as_ptr() as u64) };
@@ -52,7 +48,7 @@ extern "win64" fn GetVbtData(VbtAddress: *mut PhysicalAddress, VbtSize: *mut u32
 }
 
 extern "win64" fn GetPlatformDockStatus(_CurrentDockStatus: DockStatus) -> Status {
-    Status::from_residual(Error::Unsupported)
+    Status::UNSUPPORTED
 }
 
 #[repr(C)]
@@ -71,7 +67,7 @@ impl GopPolicy {
             GetPlatformLidStatus,
             GetVbtData,
             GetPlatformDockStatus,
-            GopOverrideGuid: NULL_GUID,
+            GopOverrideGuid: Guid::NULL,
         })
     }
 
@@ -80,7 +76,12 @@ impl GopPolicy {
 
         let self_ptr = Box::into_raw(self);
         let mut handle = Handle(0);
-        (uefi.BootServices.InstallProtocolInterface)(&mut handle, &GOP_POLICY_GUID, InterfaceType::Native, self_ptr as usize)?;
+        Result::from((uefi.BootServices.InstallProtocolInterface)(
+            &mut handle,
+            &GOP_POLICY_GUID,
+            InterfaceType::Native,
+            self_ptr as usize
+        ))?;
 
         //let _ = (uefi.BootServices.UninstallProtocolInterface)(handle, &GOP_POLICY_GUID, self_ptr as usize);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,16 +2,12 @@
 
 #![no_std]
 #![no_main]
-#![feature(try_trait_v2)]
 #![allow(non_snake_case)]
 
 #[macro_use]
 extern crate uefi_std as std;
 
 use std::prelude::*;
-
-use core::ops::FromResidual;
-use std::uefi::status::Status;
 
 mod gop_policy;
 
@@ -20,8 +16,8 @@ pub extern "C" fn main() -> Status {
     let gop_policy = gop_policy::GopPolicy::new();
     if let Err(err) = gop_policy.install() {
         println!("GopPolicy error: {:?}", err);
-        Status::from_residual(err)
+        err
     } else {
-        Status(0)
+        Status::SUCCESS
     }
 }


### PR DESCRIPTION
This version will allow compiling using a stable toolchain.