### PR TITLE
Remove heap allocation

### DIFF
--- a/src/gop_policy.rs
+++ b/src/gop_policy.rs
@@ -4,7 +4,6 @@
 #![allow(unused)]
 
 use std::prelude::*;
-use std::uefi::boot::InterfaceType;
 use std::uefi::memory::PhysicalAddress;
 
 static VBT: &[u8] = include_bytes!(env!("FIRMWARE_OPEN_VBT"));
@@ -72,29 +71,10 @@ extern "efiapi" fn GetPlatformDockStatus(_CurrentDockStatus: DockStatus) -> Stat
     Status::UNSUPPORTED
 }
 
-impl GopPolicy {
-    pub fn new() -> Box<Self> {
-        Box::new(Self {
-            Revision: Self::REVISION_03,
-            GetPlatformLidStatus,
-            GetVbtData,
-            GetPlatformDockStatus,
-            GopOverrideGuid: Guid::NULL,
-        })
-    }
-
-    pub fn install(self: Box<Self>) -> Result<()> {
-        let uefi = unsafe { std::system_table_mut() };
-
-        let self_ptr = Box::into_raw(self);
-        let mut handle = Handle(0);
-        Result::from((uefi.BootServices.InstallProtocolInterface)(
-            &mut handle,
-            &Self::GUID,
-            InterfaceType::Native,
-            self_ptr as usize,
-        ))?;
-
-        Ok(())
-    }
-}
+pub static GOP_POLICY: GopPolicy = GopPolicy {
+    Revision: GopPolicy::REVISION_03,
+    GetPlatformLidStatus,
+    GetVbtData,
+    GetPlatformDockStatus,
+    GopOverrideGuid: Guid::NULL,
+};

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,20 +3,23 @@
 #![no_std]
 #![no_main]
 
-#[macro_use]
 extern crate uefi_std as std;
-
-use std::prelude::*;
 
 mod gop_policy;
 
+use gop_policy::{GopPolicy, GOP_POLICY};
+use std::prelude::*;
+use std::uefi::boot::InterfaceType;
+
 #[no_mangle]
 pub extern "C" fn main() -> Status {
-    let gop_policy = gop_policy::GopPolicy::new();
-    if let Err(err) = gop_policy.install() {
-        println!("GopPolicy error: {:?}", err);
-        err
-    } else {
-        Status::SUCCESS
-    }
+    let uefi = unsafe { std::system_table_mut() };
+    let mut handle = Handle(0);
+
+    (uefi.BootServices.InstallProtocolInterface)(
+        &mut handle,
+        &GopPolicy::GUID,
+        InterfaceType::Native,
+        core::ptr::addr_of!(GOP_POLICY) as usize,
+    )
 }


### PR DESCRIPTION
Since all protocol fields are known at compile time, replace the heap allocation with a static variable.

### Test

- Driver does not crash when loaded/unloaded in QEMU
- pre-OS graphics output still works, I guess?