### PR TITLE
Use default alignment

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,8 +9,6 @@ fn main() {
         println!("cargo::rustc-link-arg=/stack:0,0");
         println!("cargo::rustc-link-arg=/dll");
         println!("cargo::rustc-link-arg=/base:0");
-        println!("cargo::rustc-link-arg=/align:32");
-        println!("cargo::rustc-link-arg=/filealign:32");
         println!("cargo::rustc-link-arg=/subsystem:efi_boot_service_driver");
     }
 }


### PR DESCRIPTION
Fixes the following edk2 warning:

    !!!!!!!!  Image Section Alignment(0x20) does not match Required Alignment (0x1000)  !!!!!!!!